### PR TITLE
Added some methods and functions to `option` and `result`

### DIFF
--- a/expression/core/option.py
+++ b/expression/core/option.py
@@ -15,12 +15,12 @@ from typing import TYPE_CHECKING, Any, ClassVar, TypeAlias, TypeGuard, TypeVar, 
 from .curry import curry_flip
 from .error import EffectError
 from .pipe import PipeMixin
-from .result import Error, Ok, Result
 from .typing import GenericValidator, ModelField, SupportsValidation
 
 
 if TYPE_CHECKING:
     from expression.collections.seq import Seq
+    from expression.core.result import Result
 
 _TSource = TypeVar("_TSource")
 _TResult = TypeVar("_TResult")
@@ -158,7 +158,7 @@ class BaseOption(
         return of_result(result)
 
     @abstractmethod
-    def to_optional(self) -> Optional[_TSource]:
+    def to_optional(self) -> _TSource | None:
         """Convert option to an optional."""
         raise NotImplementedError
 
@@ -293,16 +293,20 @@ class Some(BaseOption[_TSource]):
 
         return Seq.of(self._value)
 
-    def to_optional(self) -> Optional[_TSource]:
+    def to_optional(self) -> _TSource | None:
         """Convert option to an optional."""
         return self._value
 
     def to_result(self, error: _TError) -> Result[_TSource, _TError]:
         """Convert option to a result."""
+        from expression.core.result import Ok
+
         return Ok(self._value)
 
     def to_result_with(self, error: Callable[[], _TError]) -> Result[_TSource, _TError]:
         """Convert option to a result."""
+        from expression.core.result import Ok
+
         return Ok(self._value)
 
     def dict(self) -> _TSource:
@@ -419,16 +423,20 @@ class Nothing_(BaseOption[_TSource], EffectError):
 
         return Seq()
 
-    def to_optional(self) -> Optional[_TSource]:
+    def to_optional(self) -> _TSource | None:
         """Convert option to an optional."""
         return None
 
     def to_result(self, error: _TError) -> Result[_TSource, _TError]:
         """Convert option to a result."""
+        from expression.core.result import Error
+
         return Error(error)
 
     def to_result_with(self, error: Callable[[], _TError]) -> Result[_TSource, _TError]:
         """Convert option to a result."""
+        from expression.core.result import Error
+
         return Error(error())
 
     def dict(self) -> builtins.dict[str, Any]:
@@ -564,7 +572,7 @@ def to_seq(option: Option[_TSource]) -> Seq[_TSource]:
     return option.to_seq()
 
 
-def to_optional(value: Option[_TSource]) -> Optional[_TSource]:
+def to_optional(value: Option[_TSource]) -> _TSource | None:
     """Convert an option value to an optional.
 
     Args:
@@ -606,6 +614,8 @@ def of_obj(value: Any) -> Option[Any]:
 
 
 def of_result(result: Result[_TSource, _TError]) -> Option[_TSource]:
+    from expression.core.result import Ok
+
     match result:
         case Ok(value):
             return Some(value)

--- a/tests/test_option.py
+++ b/tests/test_option.py
@@ -6,7 +6,18 @@ from hypothesis import strategies as st
 from pydantic import BaseModel
 from tests.utils import CustomException
 
-from expression import Nothing, Option, Some, effect, option, pipe, pipe2
+from expression import (
+    Error,
+    Nothing,
+    Ok,
+    Option,
+    Result,
+    Some,
+    effect,
+    option,
+    pipe,
+    pipe2,
+)
 from expression.core.option import BaseOption, Nothing_
 from expression.extra.option import pipeline
 
@@ -319,6 +330,50 @@ def test_option_of_object_none():
 def test_option_of_object_value():
     xs = option.of_obj(42)
     assert xs.is_some()
+
+
+def test_option_of_result_ok():
+    result: Result[int, Any] = Ok(42)
+    xs = option.of_result(result)
+    assert xs.is_some()
+
+
+def test_option_of_result_error():
+    xs: Option[int] = option.of_result(Error("oops"))
+    assert xs.is_none()
+
+
+def test_option_to_result_ok():
+    xs = option.to_result(Some(42), "oops")
+    assert xs == Ok(42)
+
+
+def test_option_to_result_error():
+    xs = option.to_result(Nothing, "oops")
+    assert xs == Error("oops")
+
+
+def test_option_to_result_with_ok():
+    def raise_error() -> Any:
+        raise Exception("Should not be called")
+
+    xs = option.to_result_with(Some(42), error=raise_error)
+    assert xs == Ok(42)
+
+
+def test_option_to_result_with_error():
+    xs = option.to_result_with(Nothing, error=lambda: "oops")
+    assert xs == Error("oops")
+
+
+def test_option_to_optional_some():
+    xs = option.to_optional(Some(1))
+    assert xs == 1
+
+
+def test_option_to_optional_nothing():
+    xs = option.to_optional(Nothing)
+    assert xs is None
 
 
 def test_option_builder_zero():


### PR DESCRIPTION
* Convert `Option`s to `Result`s and vice versa
* Added `Option#to_optional` for easy convertion to Python's `Optional[T]`
* Added a `Result#swap` method
* Added tests for all of the above

Also:
* Fixed some documentation for `Result#default_values` and `Result#default_with`