### PR TITLE
Update README and mentions of python 3.9 to python 3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,38 @@ xs = fn()
 assert xs is Nothing
 ```
 
+### Option as an applicative
+
+Sometimes wish to combine two Options together via a function to produce a new Option
+i.e. we want to combine them only in the case when they are **both** Some. But if
+either one is Nothing, then the overall outcome should also be Nothing.
+We can use the function map2 to achieve this purpose.
+
+```python
+from expression import Some, Nothing, Option
+from operator import add
+
+def keep_positive(a: int) -> Option[int]:
+    if a > 0:
+        return Some(a)
+    else:
+      return Nothing
+
+def add_options(a: Option[int], b: Option[int]):
+  return a.map2(add, b)
+
+assert add_options(
+  keep_positive(4),
+  keep_positive(-2)
+) is Nothing
+
+assert add_options(
+  keep_positive(3),
+  keep_positive(2)
+) == Some(5)
+
+```
+
 For more information about options:
 
 - [Tutorial](https://expression.readthedocs.io/en/latest/tutorial/optional_values.html)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 > Pragmatic functional programming
 
 Expression aims to be a solid, type-safe, pragmatic, and high performance
-library for frictionless and practical functional programming in Python 3.9+.
+library for frictionless and practical functional programming in Python 3.11+.
 
 By pragmatic, we mean that the goal of the library is to use simple abstractions
 to enable you to do practical and productive functional programming in Python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "Expression"
 version = "0.0.0" # NOTE: will be updated by publish script
-description = "Practical functional programming for Python 3.9+"
+description = "Practical functional programming for Python 3.11+"
 readme = "README.md"
 authors = ["Dag Brattli <dag.brattli@cognite.com>"]
 license = "MIT License"
@@ -13,8 +13,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]


### PR DESCRIPTION
1. Changed mentions of python 3.9 to python 3.11
2. Added an example of applicative for options in reference to [issue-145](https://github.com/dbrattli/Expression/issues/145)