### PR TITLE
Make Option covariant

### DIFF
--- a/expression/core/option.py
+++ b/expression/core/option.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from expression.core.result import Result
 
 
-_TSource = TypeVar("_TSource")
+_TSource = TypeVar("_TSource", covariant=True)
 _TResult = TypeVar("_TResult")
 _TError = TypeVar("_TError")
 
@@ -47,7 +47,7 @@ class Option(
     some: _TSource = case()
 
     @staticmethod
-    def Some(value: _TSource) -> Option[_TSource]:
+    def Some(value: _T1) -> Option[_T1]:
         """Create a Some option."""
         return Option(some=value)
 
@@ -56,7 +56,7 @@ class Option(
         """Create a None option."""
         return Option(none=None)
 
-    def default_value(self, value: _TSource) -> _TSource:
+    def default_value(self, value: _T1) -> _TSource | _T1:
         """Get with default value.
 
         Gets the value of the option if the option is Some, otherwise
@@ -191,8 +191,8 @@ class Option(
             case _:
                 return True
 
-    @classmethod
-    def of_obj(cls, value: _TSource) -> Option[_TSource]:
+    @staticmethod
+    def of_obj(value: _T1) -> Option[_T1]:
         """Convert object to an option."""
         return of_optional(value)
 

--- a/tests/test_option.py
+++ b/tests/test_option.py
@@ -106,6 +106,7 @@ def test_option_none_not_equals_some():
     assert xs != ys
     assert ys != xs
 
+
 def test_option_order_some_some_works():
     xs = Some(42)
     ys = Some(41)
@@ -121,6 +122,7 @@ def test_option_order_some_none_works():
     assert xs > ys
     assert ys < xs
 
+
 def test_option_order_none_none_works():
     xs = Nothing
     ys = Nothing
@@ -128,10 +130,8 @@ def test_option_order_none_none_works():
     assert not (xs < ys)
 
 
-
-
 def test_option_none_default_value():
-    xs = Nothing
+    xs: Option[int] = Nothing
 
     zs = xs.default_value(42)
 
@@ -224,7 +224,7 @@ def test_option_none_map():
     assert ys is Nothing
 
 
-@given(st.integers(), st.integers()) # type: ignore
+@given(st.integers(), st.integers())  # type: ignore
 def test_option_some_map2_piped(x: int, y: int):
     xs = Some(x)
     ys = Some(y)
@@ -602,3 +602,18 @@ def test_serialize_option_works():
     assert model_.one.value == 10
     assert model_.two == Nothing
     assert model_.three == Nothing
+
+
+class A:
+    pass
+
+
+class B(A):
+    pass
+
+
+def test_option_covariance() -> None:
+    x: Option[B] = Some(B())
+    y: Option[A] = x
+
+    assert y.is_some()


### PR DESCRIPTION
Trying to make Option covariant. This type checks, but there could be false negatives since you can never really trust type checkers in Python.

Fixes #171 