### PR TITLE
Feat support py310

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/expression/collections/block.py
+++ b/expression/collections/block.py
@@ -24,7 +24,9 @@ import builtins
 import functools
 import itertools
 from collections.abc import Callable, Collection, Iterable, Iterator, Sequence
-from typing import TYPE_CHECKING, Any, Literal, TypeVar, TypeVarTuple, get_args, overload
+from typing import TYPE_CHECKING, Any, Literal, TypeVar, get_args, overload
+
+from typing_extensions import TypeVarTuple, Unpack
 
 
 if TYPE_CHECKING:
@@ -237,7 +239,7 @@ class Block(
         """
         return Block((*builtins.map(mapping, self),))
 
-    def starmap(self: Block[tuple[*_P]], mapping: Callable[[*_P], _TResult]) -> Block[_TResult]:
+    def starmap(self: Block[tuple[Unpack[_P]]], mapping: Callable[[Unpack[_P]], _TResult]) -> Block[_TResult]:
         """Starmap source sequence.
 
         Unpack arguments grouped as tuple elements. Builds a new collection
@@ -746,7 +748,7 @@ def reduce(
     return source.tail().fold(reduction, source.head())
 
 
-def starmap(mapper: Callable[[*_P], _TResult]) -> Callable[[Block[tuple[*_P]]], Block[_TResult]]:
+def starmap(mapper: Callable[[Unpack[_P]], _TResult]) -> Callable[[Block[tuple[Unpack[_P]]]], Block[_TResult]]:
     """Starmap source sequence.
 
     Unpack arguments grouped as tuple elements. Builds a new collection
@@ -760,7 +762,7 @@ def starmap(mapper: Callable[[*_P], _TResult]) -> Callable[[Block[tuple[*_P]]], 
         Partially applied map function.
     """
 
-    def mapper_(args: tuple[*_P]) -> _TResult:
+    def mapper_(args: tuple[Unpack[_P]]) -> _TResult:
         return mapper(*args)
 
     return map(mapper_)

--- a/expression/core/compose.py
+++ b/expression/core/compose.py
@@ -1,6 +1,8 @@
 from collections.abc import Callable
 from functools import reduce
-from typing import Any, TypeVar, TypeVarTuple, overload
+from typing import Any, TypeVar, overload
+
+from typing_extensions import TypeVarTuple, Unpack
 
 
 _A = TypeVar("_A")
@@ -139,26 +141,30 @@ def starcompose() -> Callable[[Any], Any]: ...
 
 
 @overload
-def starcompose(__fn1: Callable[[*_P], _A]) -> Callable[[*_P], _A]: ...
-
-
-@overload
-def starcompose(__fn1: Callable[[*_P], tuple[*_Y]], __fn2: Callable[[*_Y], _B]) -> Callable[[*_P], _B]: ...
+def starcompose(__fn1: Callable[[Unpack[_P]], _A]) -> Callable[[Unpack[_P]], _A]: ...
 
 
 @overload
 def starcompose(
-    __fn1: Callable[[*_P], tuple[*_Y]], __fn2: Callable[[*_Y], tuple[*_Z]], __fn3: Callable[[*_Z], _C]
-) -> Callable[[*_P], _C]: ...
+    __fn1: Callable[[Unpack[_P]], tuple[Unpack[_Y]]], __fn2: Callable[[Unpack[_Y]], _B]
+) -> Callable[[Unpack[_P]], _B]: ...
 
 
 @overload
 def starcompose(
-    __fn1: Callable[[*_P], tuple[*_Y]],
-    __fn2: Callable[[*_Y], tuple[*_Z]],
-    __fn3: Callable[[*_Z], tuple[*_X]],
-    __fn4: Callable[[*_X], _D],
-) -> Callable[[*_P], _D]: ...
+    __fn1: Callable[[Unpack[_P]], tuple[Unpack[_Y]]],
+    __fn2: Callable[[Unpack[_Y]], tuple[Unpack[_Z]]],
+    __fn3: Callable[[Unpack[_Z]], _C],
+) -> Callable[[Unpack[_P]], _C]: ...
+
+
+@overload
+def starcompose(
+    __fn1: Callable[[Unpack[_P]], tuple[Unpack[_Y]]],
+    __fn2: Callable[[Unpack[_Y]], tuple[Unpack[_Z]]],
+    __fn3: Callable[[Unpack[_Z]], tuple[Unpack[_X]]],
+    __fn4: Callable[[Unpack[_X]], _D],
+) -> Callable[[Unpack[_P]], _D]: ...
 
 
 def starcompose(*fns: Callable[..., Any]) -> Callable[..., Any]:

--- a/expression/core/misc.py
+++ b/expression/core/misc.py
@@ -1,7 +1,7 @@
 from collections.abc import Callable
 from typing import Any, TypeVar
 
-from typing_extensions import TypeVarTuple
+from typing_extensions import TypeVarTuple, Unpack
 
 
 _A = TypeVar("_A")
@@ -19,7 +19,7 @@ def identity(value: _A) -> _A:
     return value
 
 
-def starid(*value: *_P) -> tuple[*_P]:
+def starid(*value: Unpack[_P]) -> tuple[Unpack[_P]]:
     return value
 
 

--- a/expression/core/option.py
+++ b/expression/core/option.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 
 import builtins
 from collections.abc import Callable, Generator, Iterable
-from typing import TYPE_CHECKING, Any, Literal, TypeGuard, TypeVar, TypeVarTuple, get_args, get_origin
+from typing import TYPE_CHECKING, Any, Literal, TypeGuard, TypeVar, get_args, get_origin
+
+from typing_extensions import TypeVarTuple, Unpack
 
 from .curry import curry_flip
 from .error import EffectError
@@ -106,7 +108,7 @@ class Option(
             case _:
                 return Nothing
 
-    def starmap(self: Option[tuple[*_P]], mapper: Callable[[*_P], _TResult]) -> Option[_TResult]:
+    def starmap(self: Option[tuple[Unpack[_P]]], mapper: Callable[[Unpack[_P]], _TResult]) -> Option[_TResult]:
         """Starmap option.
 
         Applies the mapper to the values if the option is Some,
@@ -431,7 +433,7 @@ def map2(opt1: Option[_T1], opt2: Option[_T2], mapper: Callable[[_T1, _T2], _TRe
 
 
 @curry_flip(1)
-def starmap(option: Option[tuple[*_P]], mapper: Callable[[*_P], _TResult]) -> Option[_TResult]:
+def starmap(option: Option[tuple[Unpack[_P]]], mapper: Callable[[*_P], _TResult]) -> Option[_TResult]:
     return option.starmap(mapper)
 
 

--- a/expression/core/pipe.py
+++ b/expression/core/pipe.py
@@ -13,7 +13,9 @@ Example:
 """
 
 from collections.abc import Callable
-from typing import Any, TypeVar, TypeVarTuple, cast, overload
+from typing import Any, TypeVar, cast, overload
+
+from typing_extensions import TypeVarTuple, Unpack
 
 from .compose import compose, starcompose
 from .misc import starid
@@ -181,52 +183,54 @@ def pipe3(__values: Any, *fns: Any) -> Any:
 
 
 @overload
-def starpipe(__args: tuple[*_P], __fn1: Callable[[*_P], _B]) -> _B: ...
-
-
-@overload
-def starpipe(__args: tuple[*_P], __fn1: Callable[[*_P], tuple[*_Q]], __fn2: Callable[[*_Q], _B]) -> _B: ...
+def starpipe(__args: tuple[Unpack[_P]], __fn1: Callable[[Unpack[_P]], _B]) -> _B: ...
 
 
 @overload
 def starpipe(
-    __args: tuple[*_P],
-    __fn1: Callable[[*_P], tuple[*_Q]],
-    __fn2: Callable[[*_Q], tuple[*_X]],
-    __fn3: Callable[[*_X], _B],
+    __args: tuple[Unpack[_P]], __fn1: Callable[[Unpack[_P]], tuple[Unpack[_Q]]], __fn2: Callable[[*_Q], _B]
 ) -> _B: ...
 
 
 @overload
 def starpipe(
-    __args: tuple[*_P],
-    __fn1: Callable[[*_P], tuple[*_Q]],
-    __fn2: Callable[[*_Q], tuple[*_X]],
-    __fn3: Callable[[*_X], tuple[*_Y]],
-    __fn4: Callable[[*_Y], _B],
+    __args: tuple[Unpack[_P]],
+    __fn1: Callable[[Unpack[_P]], tuple[Unpack[_Q]]],
+    __fn2: Callable[[Unpack[_Q]], tuple[Unpack[_X]]],
+    __fn3: Callable[[Unpack[_X]], _B],
 ) -> _B: ...
 
 
 @overload
 def starpipe(
-    __args: tuple[*_P],
-    __fn1: Callable[[*_P], tuple[*_Q]],
-    __fn2: Callable[[*_Q], tuple[*_X]],
-    __fn3: Callable[[*_X], tuple[*_Y]],
-    __fn4: Callable[[*_Y], tuple[*_Z]],
-    __fn5: Callable[[*_Z], _B],
+    __args: tuple[Unpack[_P]],
+    __fn1: Callable[[Unpack[_P]], tuple[Unpack[_Q]]],
+    __fn2: Callable[[Unpack[_Q]], tuple[Unpack[_X]]],
+    __fn3: Callable[[Unpack[_X]], tuple[Unpack[_Y]]],
+    __fn4: Callable[[Unpack[_Y]], _B],
 ) -> _B: ...
 
 
 @overload
 def starpipe(
-    __args: tuple[*_P],
-    __fn1: Callable[[*_P], tuple[*_Q]],
-    __fn2: Callable[[*_Q], tuple[*_X]],
-    __fn3: Callable[[*_X], tuple[*_Y]],
-    __fn4: Callable[[*_Y], tuple[*_Z]],
-    __fn5: Callable[[*_Z], tuple[*_K]],
-    __fn6: Callable[[*_K], _B],
+    __args: tuple[Unpack[_P]],
+    __fn1: Callable[[Unpack[_P]], tuple[Unpack[_Q]]],
+    __fn2: Callable[[Unpack[_Q]], tuple[Unpack[_X]]],
+    __fn3: Callable[[Unpack[_X]], tuple[Unpack[_Y]]],
+    __fn4: Callable[[Unpack[_Y]], tuple[Unpack[_Z]]],
+    __fn5: Callable[[Unpack[_Z]], _B],
+) -> _B: ...
+
+
+@overload
+def starpipe(
+    __args: tuple[Unpack[_P]],
+    __fn1: Callable[[Unpack[_P]], tuple[Unpack[_Q]]],
+    __fn2: Callable[[Unpack[_Q]], tuple[Unpack[_X]]],
+    __fn3: Callable[[Unpack[_X]], tuple[Unpack[_Y]]],
+    __fn4: Callable[[Unpack[_Y]], tuple[Unpack[_Z]]],
+    __fn5: Callable[[Unpack[_Z]], tuple[Unpack[_K]]],
+    __fn6: Callable[[Unpack[_K]], _B],
 ) -> _B: ...
 
 

--- a/expression/core/tagged_union.py
+++ b/expression/core/tagged_union.py
@@ -1,7 +1,9 @@
 from collections.abc import Callable
 from copy import deepcopy
 from dataclasses import dataclass, field, fields
-from typing import Any, TypeVar, dataclass_transform, overload
+from typing import Any, TypeVar, overload
+
+from typing_extensions import dataclass_transform
 
 
 _T = TypeVar("_T")

--- a/poetry.lock
+++ b/poetry.lock
@@ -796,4 +796,4 @@ pydantic = ["pydantic"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">= 3.10, < 4"
-content-hash = "c92789283718423718d1b2d80620dbc4ec93f9241a30ae30c3b566a2f214f22b"
+content-hash = "6ec019459d791d0b84844963e3199757f2e84cec0d28007754ba9d9821d76a37"

--- a/poetry.lock
+++ b/poetry.lock
@@ -13,22 +13,22 @@ files = [
 
 [[package]]
 name = "attrs"
-version = "23.2.0"
+version = "24.1.0"
 description = "Classes Without Boilerplate"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "attrs-23.2.0-py3-none-any.whl", hash = "sha256:99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1"},
-    {file = "attrs-23.2.0.tar.gz", hash = "sha256:935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30"},
+    {file = "attrs-24.1.0-py3-none-any.whl", hash = "sha256:377b47448cb61fea38533f671fba0d0f8a96fd58facd4dc518e3dac9dbea0905"},
+    {file = "attrs-24.1.0.tar.gz", hash = "sha256:adbdec84af72d38be7628e353a09b6a6790d15cd71819f6e9d7b0faa8a125745"},
 ]
 
 [package.extras]
-cov = ["attrs[tests]", "coverage[toml] (>=5.3)"]
-dev = ["attrs[tests]", "pre-commit"]
-docs = ["furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-towncrier", "towncrier", "zope-interface"]
-tests = ["attrs[tests-no-zope]", "zope-interface"]
-tests-mypy = ["mypy (>=1.6)", "pytest-mypy-plugins"]
-tests-no-zope = ["attrs[tests-mypy]", "cloudpickle", "hypothesis", "pympler", "pytest (>=4.3.0)", "pytest-xdist[psutil]"]
+benchmark = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pympler", "pytest (>=4.3.0)", "pytest-codspeed", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
+cov = ["cloudpickle", "coverage[toml] (>=5.3)", "hypothesis", "mypy (>=1.11.1)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
+dev = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
+docs = ["cogapp", "furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-towncrier", "towncrier (<24.7)"]
+tests = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
+tests-mypy = ["mypy (>=1.11.1)", "pytest-mypy-plugins"]
 
 [[package]]
 name = "certifi"
@@ -279,6 +279,20 @@ files = [
 packaging = ">=20.9"
 
 [[package]]
+name = "exceptiongroup"
+version = "1.2.2"
+description = "Backport of PEP 654 (exception groups)"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b"},
+    {file = "exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc"},
+]
+
+[package.extras]
+test = ["pytest (>=6)"]
+
+[[package]]
 name = "filelock"
 version = "3.15.4"
 description = "A platform independent file lock."
@@ -307,6 +321,7 @@ files = [
 
 [package.dependencies]
 attrs = ">=22.2.0"
+exceptiongroup = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 sortedcontainers = ">=2.1.0,<3.0.0"
 
 [package.extras]
@@ -569,9 +584,11 @@ files = [
 
 [package.dependencies]
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
+tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
@@ -714,6 +731,17 @@ files = [
 ]
 
 [[package]]
+name = "tomli"
+version = "2.0.1"
+description = "A lil' TOML parser"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
+    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.12.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
@@ -767,5 +795,5 @@ pydantic = ["pydantic"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">= 3.11, < 4"
-content-hash = "aeb8b0e25da24a10c270999f919e5e0bd4200b4b1ab0c6651391603622400a4a"
+python-versions = ">= 3.10, < 4"
+content-hash = "c92789283718423718d1b2d80620dbc4ec93f9241a30ae30c3b566a2f214f22b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,14 +13,16 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
 [tool.poetry.dependencies]
 python = ">= 3.10, < 4"
-typing-extensions = "^4.10.0"
+typing-extensions = ">=4.6.0"
 
 pydantic = {version = "^2.6.2", optional = true}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = ">= 3.11, < 4"
+python = ">= 3.10, < 4"
 typing-extensions = "^4.10.0"
 
 pydantic = {version = "^2.6.2", optional = true}
@@ -43,7 +43,7 @@ all = ["pydantic"]
 [tool.ruff]
 # Keep in sync with .pre-commit-config.yaml
 line-length = 120
-target-version = "py311"
+target-version = "py310"
 # D100: Missing docstring in public module
 # D104: Missing docstring in public package
 # D105: Missing docstring in magic method

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -5,7 +5,7 @@
   ],
   "reportImportCycles": false,
   "reportMissingImports": false,
-  "pythonVersion": "3.11",
+  "pythonVersion": "3.10",
   "typeCheckingMode": "strict",
   "reportShadowedImports": "none",
   "venv": ".venv",


### PR DESCRIPTION
related: #216 

The `match ~ case` syntax is available in `python>=3.10`. 
`TypeVarTuple` and `dataclass_transform` can be supported by `typing_extensions` included in the dependency.
Additionally, I fixed the syntax sugar for `Unpack`.