### PR TITLE
chore: update pyright

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,5 +14,5 @@ repos:
         language: node
         pass_filenames: false
         types: [python]
-        additional_dependencies: ["pyright@1.1.363"]
+        additional_dependencies: ["pyright@1.1.374"]
     repo: local

--- a/expression/collections/array.py
+++ b/expression/collections/array.py
@@ -385,7 +385,7 @@ class TypedArray(MutableSequence[_TSource], PipeMixin):
     def sum_by(self, projection: Callable[[_TSource], _TSourceSum]) -> int:
         return pipe(
             self,
-            sum_by(projection),  # type: ignore
+            sum_by(projection),
         )
 
     def tail(self) -> TypedArray[_TSource]:

--- a/expression/collections/map.py
+++ b/expression/collections/map.py
@@ -197,7 +197,7 @@ class Map(Mapping[_Key, _Value], PipeMixin):
         """
         return of_seq(sequence)
 
-    def __hash__(self) -> int:  # type: ignore
+    def __hash__(self) -> int:
         def combine_hash(x: int, y: int) -> int:
             return (x << 1) + y + 631
 

--- a/expression/core/tagged_union.py
+++ b/expression/core/tagged_union.py
@@ -41,7 +41,7 @@ def tagged_union(
 
     def transform(cls: Any) -> Any:
         cls = dataclass(init=False, repr=False, order=False, eq=False, kw_only=True)(cls)
-        fields_ = fields(cls)  # type: ignore
+        fields_ = fields(cls)
         field_names = tuple(f.name for f in fields_)
         original_init = cls.__init__
 
@@ -65,7 +65,7 @@ def tagged_union(
 
             # Enables the use of dataclasses.asdict
             union_fields = dict((f.name, f) for f in fields_ if f.name in [name, "tag"])
-            object.__setattr__(self, "__dataclass_fields__", union_fields)  # type: ignore
+            object.__setattr__(self, "__dataclass_fields__", union_fields)
             original_init(self)
 
         def __repr__(self: Any) -> str:
@@ -77,9 +77,9 @@ def tagged_union(
                 if not isinstance(other, cls):
                     return False
 
-                return (self._index, getattr(self, self.tag)) < (other._index, getattr(other, other.tag))  # type: ignore
+                return (self._index, getattr(self, self.tag)) < (other._index, getattr(other, other.tag))
 
-            cls.__lt__ = __lt__  # type: ignore
+            cls.__lt__ = __lt__
 
         if frozen:
 

--- a/expression/core/typing.py
+++ b/expression/core/typing.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from collections.abc import Iterable
-from typing import Any, Protocol, TypeVar, cast, get_origin
+from typing import Any, Protocol, TypeVar, get_origin
 
 
 _T = TypeVar("_T")
@@ -88,8 +88,7 @@ def try_downcast(type_: type[_Derived], expr: Any) -> _Derived | None:
     """
     origin: type[_Derived] | None = get_origin(type_) or type_
     if origin is not None and isinstance(expr, origin):
-        derived = cast(_Derived, expr)
-        return derived
+        return expr
 
     return None
 

--- a/expression/extra/parser.py
+++ b/expression/extra/parser.py
@@ -264,7 +264,7 @@ def sequence(parser_list: Block[Parser[_A]]) -> Parser[Block[_A]]:
     match parser_list:
         case block.empty:
             return preturn(block.empty)
-        case Block([head, *tail]):  # type: ignore
+        case Block([head, *tail]):
             tail_ = sequence(Block(tail))
             return cons_p(head)(tail_)
         case _:


### PR DESCRIPTION
Starting with `pyright>=1.1.374`, a big change to `TypeVar` has been announced,
which is said to fix a number of errors reported over the past year.

This allowed us to remove some of the old `type: ignore`.

see more: https://github.com/microsoft/pyright/releases/tag/1.1.374