### PR TITLE
fix: null times to 0

### DIFF
--- a/expression/collections/asyncseq.py
+++ b/expression/collections/asyncseq.py
@@ -62,7 +62,7 @@ async def empty() -> AsyncIterable[Any]:
 
 
 async def repeat(value: TSource, times: int | None = None) -> AsyncIterable[TSource]:
-    for value in itertools.repeat(value, times):  # type: ignore
+    for value in itertools.repeat(value, times or 0):
         yield value
 
 


### PR DESCRIPTION
The `itertools.repeat` accepts negative or positive numbers, but not null values.