### PR TITLE
Add par_map methods to collections

### DIFF
--- a/expression/collections/array.py
+++ b/expression/collections/array.py
@@ -10,9 +10,10 @@ type of input.
 from __future__ import annotations
 
 import array
+import asyncio
 import builtins
 import functools
-from collections.abc import Callable, Iterable, Iterator, MutableSequence
+from collections.abc import Awaitable, Callable, Iterable, Iterator, MutableSequence
 from enum import Enum
 from typing import Any, TypeVar, cast
 
@@ -185,7 +186,34 @@ class TypedArray(MutableSequence[_TSource], PipeMixin):
         self.typecode = typecode
 
     def map(self, mapping: Callable[[_TSource], _TResult]) -> TypedArray[_TResult]:
+        """Map array.
+
+        Builds a new array whose elements are the results of applying
+        the given function to each of the elements of the array.
+
+        Args:
+            mapping: A function to transform items from the input array.
+
+        Returns:
+            The result sequence.
+        """
         result = builtins.map(mapping, self.value)
+        return TypedArray(result)
+
+    async def par_map(self, mapping: Callable[[_TSource], Awaitable[_TResult]]) -> TypedArray[_TResult]:
+        """Map array asynchronously.
+
+        Builds a new array whose elements are the results of applying
+        the given asynchronous function to each of the elements of the
+        array.
+
+        Args:
+            mapping: A function to transform items from the input array.
+
+        Returns:
+            The result sequence.
+        """
+        result = await asyncio.gather(*(mapping(item) for item in self))
         return TypedArray(result)
 
     def choose(self, chooser: Callable[[_TSource], Option[_TResult]]) -> TypedArray[_TResult]:

--- a/expression/collections/block.py
+++ b/expression/collections/block.py
@@ -20,10 +20,11 @@ Example:
 
 from __future__ import annotations
 
+import asyncio
 import builtins
 import functools
 import itertools
-from collections.abc import Callable, Collection, Iterable, Iterator, Sequence
+from collections.abc import Awaitable, Callable, Collection, Iterable, Iterator, Sequence
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, get_args, overload
 
 from typing_extensions import TypeVarTuple, Unpack
@@ -238,6 +239,23 @@ class Block(
             The list of transformed elements.
         """
         return Block((*builtins.map(mapping, self),))
+
+    async def par_map(self, mapping: Callable[[_TSource], Awaitable[_TResult]]) -> Block[_TResult]:
+        """Map list asynchronously.
+
+        Builds a new collection whose elements are the results of
+        applying the given asynchronous function to each of the
+        elements of the collection.
+
+        Args:
+            mapping: The function to transform elements from the input
+                list.
+
+        Returns:
+            The list of transformed elements.
+        """
+        result = await asyncio.gather(*(mapping(item) for item in self))
+        return Block(result)
 
     def starmap(self: Block[tuple[Unpack[_P]]], mapping: Callable[[Unpack[_P]], _TResult]) -> Block[_TResult]:
         """Starmap source sequence.

--- a/expression/collections/seq.py
+++ b/expression/collections/seq.py
@@ -24,10 +24,11 @@ Example (fluent style):
 
 from __future__ import annotations
 
+import asyncio
 import builtins
 import functools
 import itertools
-from collections.abc import Callable, Iterable, Iterator
+from collections.abc import Awaitable, Callable, Iterable, Iterator
 from typing import TYPE_CHECKING, Any, TypeVar, cast, overload
 
 from expression.core import (
@@ -174,6 +175,22 @@ class Seq(Iterable[_TSource], PipeMixin):
             The result sequence.
         """
         return Seq(pipe(self, map(mapper)))
+
+    async def par_map(self, mapper: Callable[[_TSource], Awaitable[_TResult]]) -> Seq[_TResult]:
+        """Map sequence asynchronously.
+
+        Builds a new collection whose elements are the results of
+        applying the given asynchronous function to each of the elements
+        of the collection.
+
+        Args:
+            mapper: A function to transform items from the input sequence.
+
+        Returns:
+            The result sequence.
+        """
+        result = await asyncio.gather(*(mapper(item) for item in self))
+        return Seq(result)
 
     @overload
     def starmap(self: Seq[tuple[_T1, _T2]], mapping: Callable[[_T1, _T2], _TResult]) -> Seq[_TResult]: ...

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -1,3 +1,4 @@
+import asyncio
 import functools
 from collections.abc import Callable
 from typing import Any
@@ -428,3 +429,20 @@ def test_array_monad_law_associativity_iterable(xs: list[int]):
 
     m = array.of_seq(xs)
     assert m.collect(f).collect(g) == m.collect(lambda x: f(x).collect(g))
+
+@pytest.mark.asyncio
+async def test_par_map():
+    async def async_fn(i: int):
+        await asyncio.sleep(0.1)
+        return i * 2
+
+    xs = TypedArray(range(1, 10))
+
+    start_time = asyncio.get_event_loop().time()
+    ys = await xs.par_map(async_fn)
+    end_time = asyncio.get_event_loop().time()
+
+    assert ys == TypedArray(i * 2 for i in range(1, 10))
+
+    time_taken = end_time - start_time
+    assert time_taken < 0.2, "par_map took too long"

--- a/tests/test_seq.py
+++ b/tests/test_seq.py
@@ -1,3 +1,4 @@
+import asyncio
 import functools
 from collections.abc import Callable, Iterable
 from itertools import accumulate
@@ -382,3 +383,21 @@ def test_seq_monad_law_associativity_empty(value: int):
     # Empty list
     m = empty
     assert list(m.collect(f).collect(g)) == list(m.collect(lambda x: f(x).collect(g)))
+
+
+@pytest.mark.asyncio
+async def test_par_map():
+    async def async_fn(i: int):
+        await asyncio.sleep(0.1)
+        return i * 2
+
+    xs = seq.of_iterable(range(1, 10))
+
+    start_time = asyncio.get_event_loop().time()
+    ys = await xs.par_map(async_fn)
+    end_time = asyncio.get_event_loop().time()
+
+    assert list(ys) == [i * 2 for i in range(1, 10)]
+
+    time_taken = end_time - start_time
+    assert time_taken < 0.2, "par_map took too long"


### PR DESCRIPTION
* `par_map` facilitates running an async function across all items in the collection
* Resolves #213