### PR TITLE
docs: install Jupytext for Read the Docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 jupyter-book>=1.0.4.post1,<2.0
+jupytext>=1.19.5,<2.0
 linkify-it-py
 myst-nb
 sphinx>=7,<8


### PR DESCRIPTION
## Summary
- install the Jupytext dependency needed to load guides and tutorials in `py:percent` format during the Read the Docs Sphinx build

## Validation
- `uv run --no-project --with-requirements docs/requirements.txt python -c "import jupytext"`
- `uv run --with-requirements docs/requirements.txt sphinx-build -W -b html docs docs/_build/rtd`