### PR TITLE
fix: preserve RuntimeError propagation and support plain function bodies

### DIFF
--- a/expression/core/async_builder.py
+++ b/expression/core/async_builder.py
@@ -4,6 +4,7 @@ This module provides the base class for async builders, which are used to
 create computational expressions for async operations.
 """
 
+import inspect
 from abc import ABC
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from functools import wraps
@@ -93,14 +94,36 @@ class AsyncBuilder(Generic[_T, _M], ABC):  # Corrected Generic definition
         self,
         fn: Callable[
             _P,
-            AsyncGenerator[_T, Any],
+            AsyncGenerator[_T, Any] | Awaitable[_T | None] | _T | None,
         ],
     ) -> Callable[_P, Awaitable[_M]]:
-        """The builder decorator."""
+        """The builder decorator.
+
+        A body without a `yield` statement is a plain async function. Its
+        return value is treated like a `return` statement (F# `return`): a
+        value is lifted with `return_`, and a `None` return value maps to
+        `zero()`.
+        """
 
         @wraps(fn)
         async def wrapper(*args: _P.args, **kw: _P.kwargs) -> _M:
-            gen = fn(*args, **kw)
+            body = fn(*args, **kw)
+
+            if not inspect.isasyncgen(body):
+                # A body without a `yield` statement is a plain (async)
+                # function. Treat its return value like a `return` statement:
+                # a value maps to return_(value), a None return value maps
+                # to zero().
+                result_value: _T | None
+                if inspect.iscoroutine(body):
+                    result_value = await cast("Awaitable[_T]", body)
+                else:
+                    result_value = cast("_T | None", body)
+                if result_value is None:
+                    return await self.run(await self.zero())
+                return await self.run(await self.return_(result_value))
+
+            gen = cast("AsyncGenerator[_T, Any]", body)
             state = AsyncBuilderState[_T]()  # Initialize AsyncBuilderState
             result: _M = await self.zero()  # Initialize result
             value: _M

--- a/expression/core/builder.py
+++ b/expression/core/builder.py
@@ -1,3 +1,4 @@
+import inspect
 from abc import ABC
 from collections.abc import Callable, Generator
 from functools import wraps
@@ -83,22 +84,34 @@ class Builder(Generic[_T, _M], ABC):  # Corrected Generic definition
 
             raise  # Raise StopIteration with no value
 
-        except RuntimeError:
-            state.is_done = True
-            return self.zero()  # Return zero() to handle generator runtime errors instead of raising StopIteration
-
     def __call__(
         self,
         fn: Callable[
             _P,
-            Generator[_T | None, _T, _T | None] | Generator[_T | None, None, _T | None],
+            Generator[_T | None, _T, _T | None] | Generator[_T | None, None, _T | None] | _T | None,
         ],
     ) -> Callable[_P, _M]:
-        """The builder decorator."""
+        """The builder decorator.
+
+        A body without a `yield` statement is a plain function. Its return
+        value is treated like a `return` statement (F# `return`): a value is
+        lifted with `return_`, and a `None` return value maps to `zero()`.
+        """
 
         @wraps(fn)
         def wrapper(*args: _P.args, **kw: _P.kwargs) -> _M:
-            gen = fn(*args, **kw)
+            body = fn(*args, **kw)
+
+            if not inspect.isgenerator(body):
+                # A body without a `yield` statement is a plain function.
+                # Treat its return value like a `return` statement: a value
+                # maps to return_(value), a None return value maps to zero().
+                result_value = cast("_T | None", body)
+                if result_value is None:
+                    return self.run(self.zero())
+                return self.run(self.return_(result_value))
+
+            gen = cast("Generator[Any, Any, Any]", body)
             state = BuilderState[_T]()  # Initialize BuilderState
             result: _M = self.zero()  # Initialize result
             value: _M

--- a/expression/effect/async_option.py
+++ b/expression/effect/async_option.py
@@ -123,7 +123,11 @@ class AsyncOptionBuilder(AsyncBuilder[_TSource, Option[Any]]):
         self,
         fn: Callable[
             _P,
-            AsyncGenerator[_TSource, _TSource] | AsyncGenerator[_TSource, None],
+            AsyncGenerator[_TSource, _TSource]
+            | AsyncGenerator[_TSource, None]
+            | Awaitable[_TSource | None]
+            | _TSource
+            | None,
         ],
     ) -> Callable[_P, Awaitable[Option[_TSource]]]:
         """The builder decorator."""

--- a/expression/effect/async_result.py
+++ b/expression/effect/async_result.py
@@ -124,7 +124,11 @@ class AsyncResultBuilder(AsyncBuilder[_TSource, Result[Any, _TError]]):
         self,
         fn: Callable[
             _P,
-            AsyncGenerator[_TSource, _TSource] | AsyncGenerator[_TSource, None],
+            AsyncGenerator[_TSource, _TSource]
+            | AsyncGenerator[_TSource, None]
+            | Awaitable[_TSource | None]
+            | _TSource
+            | None,
         ],
     ) -> Callable[_P, Awaitable[Result[_TSource, _TError]]]:
         """The builder decorator."""

--- a/expression/effect/option.py
+++ b/expression/effect/option.py
@@ -99,7 +99,10 @@ class OptionBuilder(Builder[_TSource, Option[Any]]):
         self,  # Ignored self parameter
         fn: Callable[
             _P,
-            Generator[_TSource | None, _TSource, _TSource | None] | Generator[_TSource | None, None, _TSource | None],
+            Generator[_TSource | None, _TSource, _TSource | None]
+            | Generator[_TSource | None, None, _TSource | None]
+            | _TSource
+            | None,
         ],
     ) -> Callable[_P, Option[_TSource]]:
         return super().__call__(fn)

--- a/expression/effect/result.py
+++ b/expression/effect/result.py
@@ -90,7 +90,10 @@ class ResultBuilder(Builder[_TSource, Result[Any, _TError]]):
         self,  # Ignored self parameter
         fn: Callable[
             _P,
-            Generator[_TSource | None, _TSource, _TSource | None] | Generator[_TSource | None, None, _TSource | None],
+            Generator[_TSource | None, _TSource, _TSource | None]
+            | Generator[_TSource | None, None, _TSource | None]
+            | _TSource
+            | None,
         ],
     ) -> Callable[_P, Result[_TSource, _TError]]:
         return super().__call__(fn)

--- a/expression/effect/seq.py
+++ b/expression/effect/seq.py
@@ -102,7 +102,10 @@ class SeqBuilder(Builder[_TSource, Iterable[Any]]):
         self,
         fn: Callable[
             ...,
-            Generator[_TSource | None, _TSource, _TSource | None] | Generator[_TSource | None, None, _TSource | None],
+            Generator[_TSource | None, _TSource, _TSource | None]
+            | Generator[_TSource | None, None, _TSource | None]
+            | _TSource
+            | None,
         ],
     ) -> Callable[..., Iterable[_TSource]]:
         return super().__call__(fn)

--- a/tests/test_async_option_builder.py
+++ b/tests/test_async_option_builder.py
@@ -389,3 +389,41 @@ async def test_async_option_builder_with_nested_async_generators():
 
     computation = await outer_gen()
     assert computation == Some(42)  # 40 -> 41 -> 42
+
+
+@pytest.mark.asyncio
+async def test_async_option_builder_plain_function_body():
+    """A body without a yield statement is treated like a `return` statement."""
+
+    @effect.async_option[int]()
+    async def fn() -> int:
+        await asyncio.sleep(0)  # Simulate async work
+        return 42
+
+    computation = await fn()
+    assert computation == Some(42)
+
+
+@pytest.mark.asyncio
+async def test_async_option_builder_plain_function_body_none():
+    """A plain async function body returning None maps to zero()."""
+
+    @effect.async_option[int]()
+    async def fn() -> None:
+        return None
+
+    computation = await fn()
+    assert computation is Nothing
+
+
+@pytest.mark.asyncio
+async def test_async_option_builder_runtime_error_propagates():
+    """A RuntimeError raised in the body propagates instead of being swallowed."""
+
+    @effect.async_option[int]()
+    async def fn() -> AsyncGenerator[int, int]:
+        raise RuntimeError("boom")
+        yield 42  # Should not reach here
+
+    with raises(RuntimeError, match="boom"):
+        await fn()

--- a/tests/test_async_result_builder.py
+++ b/tests/test_async_result_builder.py
@@ -417,3 +417,41 @@ async def test_async_result_builder_with_nested_async_generators():
 
     computation = await outer_gen()
     assert computation == Ok(42)  # 40 -> 41 -> 42
+
+
+@pytest.mark.asyncio
+async def test_async_result_builder_plain_function_body():
+    """A body without a yield statement is treated like a `return` statement."""
+
+    @effect.async_result[int, str]()
+    async def fn() -> int:
+        await asyncio.sleep(0)  # Simulate async work
+        return 42
+
+    computation = await fn()
+    assert computation == Ok(42)
+
+
+@pytest.mark.asyncio
+async def test_async_result_builder_plain_function_body_none():
+    """A plain async function body returning None maps to zero()."""
+
+    @effect.async_result[int, str]()
+    async def fn() -> None:
+        return None
+
+    computation = await fn()
+    assert computation == Ok(None)
+
+
+@pytest.mark.asyncio
+async def test_async_result_builder_runtime_error_propagates():
+    """A RuntimeError raised in the body propagates instead of being swallowed."""
+
+    @effect.async_result[int, str]()
+    async def fn() -> AsyncGenerator[int, int]:
+        raise RuntimeError("boom")
+        yield 42  # Should not reach here
+
+    with raises(RuntimeError, match="boom"):
+        await fn()

--- a/tests/test_option_builder.py
+++ b/tests/test_option_builder.py
@@ -290,3 +290,37 @@ def test_option_builder_yield_from_nothing_short_circuit():
 
     computation = fn()
     assert computation is Nothing
+
+
+def test_option_builder_plain_function_body():
+    """A body without a yield statement is treated like a `return` statement."""
+
+    @effect.option[int]()
+    def fn() -> int:
+        return 42
+
+    computation = fn()
+    assert computation == Some(42)
+
+
+def test_option_builder_plain_function_body_none():
+    """A plain function body returning None maps to zero()."""
+
+    @effect.option[int]()
+    def fn() -> None:
+        return None
+
+    computation = fn()
+    assert computation is Nothing
+
+
+def test_option_builder_runtime_error_propagates():
+    """A RuntimeError raised in the body propagates instead of being swallowed."""
+
+    @effect.option[int]()
+    def fn() -> Generator[int, int, int]:
+        raise RuntimeError("boom")
+        yield 42  # Should not reach here
+
+    with raises(RuntimeError, match="boom"):
+        fn()

--- a/tests/test_result_builder.py
+++ b/tests/test_result_builder.py
@@ -302,3 +302,37 @@ def test_result_builder_yield_from_error_short_circuit():
             assert err == "error"
         case _:
             assert False
+
+
+def test_result_builder_plain_function_body():
+    """A body without a yield statement is treated like a `return` statement."""
+
+    @effect.result[int, str]()
+    def fn() -> int:
+        return 42
+
+    computation = fn()
+    assert computation == Ok(42)
+
+
+def test_result_builder_plain_function_body_none():
+    """A plain function body returning None maps to zero()."""
+
+    @effect.result[int, str]()
+    def fn() -> None:
+        return None
+
+    computation = fn()
+    assert computation == Ok(None)
+
+
+def test_result_builder_runtime_error_propagates():
+    """A RuntimeError raised in the body propagates instead of being swallowed."""
+
+    @effect.result[int, str]()
+    def fn() -> Generator[int, int, int]:
+        raise RuntimeError("boom")
+        yield 42  # Should not reach here
+
+    with raises(RuntimeError, match="boom"):
+        fn()

--- a/tests/test_seq_builder.py
+++ b/tests/test_seq_builder.py
@@ -251,3 +251,14 @@ def test_seq_builder_yield_from_empty_sequence_short_circuit():
 
     computation = fn()
     assert list(computation) == [43, 44, 87]
+
+
+def test_seq_builder_plain_function_body():
+    """A body without a yield statement is treated like a `return` statement."""
+
+    @effect.seq[int]()
+    def fn() -> int:
+        return 42
+
+    computation = fn()
+    assert list(computation) == [42]


### PR DESCRIPTION
Two P0 fixes to the computational-expression builder, aligning it with F# computation-expression semantics.

## 1. `RuntimeError` raised in an effect body is no longer silently swallowed

The sync `Builder._send` had an `except RuntimeError` branch that converted the error into `zero()` — a `raise` inside an effect body produced a silent empty computation (e.g. `Nothing`) with no trace. Errors now propagate to the caller, matching the async builder.

```python
@effect.option[int]()
def fn():
    raise RuntimeError("boom")
    yield 42

fn()  # before: Nothing (silent); now: RuntimeError("boom")
```

## 2. Decorated functions without a `yield` statement are now supported

Plain function bodies (e.g. `def fn(): return 42`) previously crashed with `AttributeError`. The return value is now treated like an F# `return` statement: a value is lifted with `return_`, and `None` maps to `zero()`.

```python
@effect.option[int]()
def fn() -> int:
    return 42

fn()  # Some(42) — before: AttributeError

@effect.option[int]()
def fn() -> None:
    return None

fn()  # Nothing
```

## Design notes

- A body's return value is treated like F# `return` (lifted with `return_`) rather than `return_from`, because `return_` is total and type-safe — a raw non-monad value never leaks into the monad.
- Signatures and all five effect overrides (`option`, `result`, `seq`, `async_option`, `async_result`) were widened for LSP compatibility under pyright strict.

## Verification

- 13 new regression tests across the option/result/seq/async-option/async-result builder suites (plain body, plain body `None`, `RuntimeError` propagation)
- `uv run pytest` — 491 passed
- `uv run ruff check expression/ && uv run ruff format --check expression/` — clean
- pyright: no new errors in `expression/` relative to the `main` baseline
