### PR TITLE
feat: add Seq.pairwise

### DIFF
--- a/expression/collections/seq.py
+++ b/expression/collections/seq.py
@@ -243,6 +243,10 @@ class Seq(Iterable[_TSource], PipeMixin):
         """
         return Seq(mapi(mapping)(self))
 
+    def pairwise(self) -> Seq[tuple[_TSource, _TSource]]:
+        """Return adjacent elements paired with their predecessor."""
+        return Seq(pairwise(self))
+
     @overload
     @staticmethod
     def range(stop: int) -> Iterable[int]: ...
@@ -793,6 +797,25 @@ of_list = of_iterable
 """Alias to `seq.of_iterable`."""
 
 
+def pairwise(source: Iterable[_TSource]) -> Iterable[tuple[_TSource, _TSource]]:
+    """Return adjacent elements paired with their predecessor.
+
+    The result is evaluated lazily and contains no elements when the source has
+    fewer than two elements.
+
+    Args:
+        source: The input sequence.
+
+    Returns:
+        A sequence of overlapping adjacent pairs.
+
+    Example:
+        >>> list(pairwise([1, 2, 3, 4]))
+        [(1, 2), (2, 3), (3, 4)]
+    """
+    return SeqGen(lambda: itertools.pairwise(source))
+
+
 @overload
 def range(stop: int) -> Iterable[int]: ...
 
@@ -1003,6 +1026,7 @@ __all__ = [
     "of",
     "of_iterable",
     "of_list",
+    "pairwise",
     "range",
     "scan",
     "singleton",

--- a/tests/test_seq.py
+++ b/tests/test_seq.py
@@ -318,6 +318,51 @@ def test_seq_infinite(xs: list[int]):
     assert expected == list(ys)
 
 
+@given(st.lists(st.integers()))  # type: ignore
+def test_seq_pairwise_pipe(xs: list[int]):
+    pairs = pipe(xs, seq.pairwise)
+
+    assert list(pairs) == list(zip(xs, xs[1:]))
+
+
+@given(st.lists(st.integers()))  # type: ignore
+def test_seq_pairwise_fluent(xs: list[int]):
+    source = Seq[int].of_iterable(xs)
+    pairs = source.pairwise()
+
+    assert list(pairs) == list(zip(xs, xs[1:]))
+
+
+def test_seq_pairwise_short_sources_are_empty():
+    empty: list[int] = []
+
+    assert list(seq.pairwise(empty)) == []
+    assert list(seq.pairwise([1])) == []
+
+
+def test_seq_pairwise_preserves_repeatable_sources():
+    pairs = seq.pairwise([1, 2, 3])
+
+    assert list(pairs) == [(1, 2), (2, 3)]
+    assert list(pairs) == [(1, 2), (2, 3)]
+
+
+def test_seq_pairwise_is_lazy():
+    consumed: list[int] = []
+
+    def source() -> Iterable[int]:
+        for value in [1, 2, 3]:
+            consumed.append(value)
+            yield value
+
+    pairs = seq.pairwise(source())
+    assert consumed == []
+
+    iterator = iter(pairs)
+    assert next(iterator) == (1, 2)
+    assert consumed == [1, 2]
+
+
 rtn: Callable[[int], Seq[int]] = seq.singleton
 empty: Seq[int] = seq.empty
 


### PR DESCRIPTION
## Summary

- add a lazy functional `seq.pairwise` operation
- add the fluent `Seq.pairwise` API
- export and document the new operation
- cover pipeline and fluent usage, short inputs, repeatability, and lazy consumption

This is a focused contribution toward #82.

## Validation

- `uv run pytest` — 483 passed
- `uv run pre-commit run --all-files --show-diff-on-failure` — passed
- `uv build` — source distribution and wheel built successfully