### PR TITLE
feat: add Seq.try_pick

### DIFF
--- a/expression/collections/seq.py
+++ b/expression/collections/seq.py
@@ -328,6 +328,10 @@ class Seq(Iterable[_TSource], PipeMixin):
         """Return the index of the first element matching the predicate, if any."""
         return pipe(self, try_find_index(predicate))
 
+    def try_pick(self, chooser: Callable[[_TSource], Option[_TResult]]) -> Option[_TResult]:
+        """Return the first value produced by the chooser, if any."""
+        return pipe(self, try_pick(chooser))
+
     def dict(self) -> Iterable[_TSource]:
         """Returns a json serializable representation of the list."""
 
@@ -975,6 +979,33 @@ def try_find_index(source: Iterable[_TSource], predicate: Callable[[_TSource], b
 
 
 @curry_flip(1)
+def try_pick(source: Iterable[_TSource], chooser: Callable[[_TSource], Option[_TResult]]) -> Option[_TResult]:
+    """Return the first value produced by the chooser, if any.
+
+    The chooser is evaluated in sequence order, and evaluation stops as
+    soon as it returns `Some`.
+
+    Args:
+        source: The input sequence.
+        chooser: A function that transforms elements into optional results.
+
+    Returns:
+        The first result wrapped in `Some`, or `Nothing` when the chooser
+        returns `Nothing` for every element.
+
+    Example:
+        >>> pipe([1, 2, 3], try_pick(lambda value: Option.of_obj(value * 10 if value % 2 == 0 else None)))
+        Some 20
+    """
+    for value in source:
+        result = chooser(value)
+        if result.is_some():
+            return result
+
+    return Nothing
+
+
+@curry_flip(1)
 def unfold(state: _TState, generator: Callable[[_TState], Option[tuple[_TSource, _TState]]]) -> Iterable[_TSource]:
     """Unfold sequence.
 
@@ -1068,6 +1099,7 @@ __all__ = [
     "tail",
     "take",
     "try_find_index",
+    "try_pick",
     "unfold",
     "zip",
 ]

--- a/tests/test_seq.py
+++ b/tests/test_seq.py
@@ -414,6 +414,58 @@ def test_seq_try_find_index_propagates_predicate_exceptions():
         pipe([1], seq.try_find_index(predicate))
 
 
+def test_seq_try_pick_pipe_returns_first_transformed_value():
+    choose_even: Callable[[int], Option[str]] = lambda value: Some(str(value)) if value % 2 == 0 else Nothing
+    result = pipe([1, 2, 4], seq.try_pick(choose_even))
+
+    assert result == Some("2")
+
+
+def test_seq_try_pick_fluent():
+    choose_even: Callable[[int], Option[str]] = lambda value: Some(str(value)) if value % 2 == 0 else Nothing
+    source = Seq[int].of_iterable([1, 2, 4])
+
+    assert source.try_pick(choose_even) == Some("2")
+
+
+def test_seq_try_pick_returns_nothing_without_a_choice():
+    empty: list[int] = []
+    never_choose: Callable[[int], Option[str]] = lambda _: Nothing
+
+    assert pipe(empty, seq.try_pick(never_choose)) is Nothing
+    assert pipe([1, 2], seq.try_pick(never_choose)) is Nothing
+
+
+def test_seq_try_pick_preserves_some_none():
+    choose_none: Callable[[int], Option[None]] = lambda value: Some(None) if value == 2 else Nothing
+    result = pipe([1, 2, 3], seq.try_pick(choose_none))
+
+    assert result == Some(None)
+
+
+def test_seq_try_pick_stops_after_first_choice():
+    consumed: list[int] = []
+    choose_two: Callable[[int], Option[int]] = lambda value: Some(value * 10) if value == 2 else Nothing
+
+    def source() -> Iterable[int]:
+        for value in [1, 2, 3]:
+            consumed.append(value)
+            yield value
+
+    result = pipe(source(), seq.try_pick(choose_two))
+
+    assert result == Some(20)
+    assert consumed == [1, 2]
+
+
+def test_seq_try_pick_propagates_chooser_exceptions():
+    def chooser(_: int) -> Option[str]:
+        raise ValueError("chooser failed")
+
+    with pytest.raises(ValueError, match="chooser failed"):
+        pipe([1], seq.try_pick(chooser))
+
+
 rtn: Callable[[int], Seq[int]] = seq.singleton
 empty: Seq[int] = seq.empty
 


### PR DESCRIPTION
## Summary

- add F#-compatible `Seq.try_pick` for transformed first-match lookup
- support both pipeline and fluent APIs
- stop evaluating immediately after the chooser returns `Some`
- preserve `Some(None)` by returning the chooser's original `Option`

This is a focused contribution toward #82 and intentionally does not add the other sequence operations tracked there.

## Verification

- `uv run pytest tests/test_seq.py -k try_pick` (6 passed)
- `uv run pytest` (502 passed)
- `uv run pre-commit run --all-files --show-diff-on-failure`
- `uv build`