### PR TITLE
feat: add Seq.take_while

### DIFF
--- a/expression/collections/seq.py
+++ b/expression/collections/seq.py
@@ -321,6 +321,19 @@ class Seq(Iterable[_TSource], PipeMixin):
         """
         return Seq(pipe(self, take(count)))
 
+    def take_while(self, predicate: Callable[[_TSource], bool]) -> Seq[_TSource]:
+        """Returns elements while a predicate holds.
+
+        Returns a sequence that yields elements from the underlying
+        sequence while the given predicate returns `True`, and then
+        skips the remaining elements.
+
+        Args:
+            predicate: A function that evaluates to `False` when no more
+                items should be returned.
+        """
+        return Seq(pipe(self, take_while(predicate)))
+
     def to_list(self) -> Block[_TSource]:
         return to_list(self)
 
@@ -946,6 +959,32 @@ def take(source: Iterable[_TSource], count: int) -> Iterable[_TSource]:
     return Seq()
 
 
+@curry_flip(1)
+def take_while(source: Iterable[_TSource], predicate: Callable[[_TSource], bool]) -> Iterable[_TSource]:
+    """Returns elements while a predicate holds.
+
+    Returns a sequence that yields elements from the underlying
+    sequence while the given predicate returns `True`, and then
+    skips the remaining elements.
+
+    Args:
+        source: The source sequence.
+        predicate: A function that evaluates to `False` when no more
+            items should be returned.
+
+    Returns:
+        The result sequence.
+    """
+
+    def gen() -> Iterator[_TSource]:
+        for item in source:
+            if not predicate(item):
+                break
+            yield item
+
+    return SeqGen(gen)
+
+
 def to_list(source: Iterable[_TSource]) -> Block[_TSource]:
     from .block import Block
 
@@ -1098,6 +1137,7 @@ __all__ = [
     "sum_by",
     "tail",
     "take",
+    "take_while",
     "try_find_index",
     "try_pick",
     "unfold",

--- a/tests/test_seq.py
+++ b/tests/test_seq.py
@@ -1,6 +1,6 @@
 import functools
 from collections.abc import Callable, Iterable
-from itertools import accumulate
+from itertools import accumulate, takewhile
 from typing import Any, Optional
 
 import pytest
@@ -246,6 +246,43 @@ def test_seq_take_is_lazy():
     xs = seq.infinite
 
     ys = pipe(xs, seq.take(5))
+    assert list(ys) == [0, 1, 2, 3, 4]
+
+
+@given(st.lists(st.integers()))  # type: ignore
+def test_seq_take_while(xs: list[int]):
+    def predicate(x: int) -> bool:
+        return x >= 0
+
+    ys = seq.of_iterable(xs)
+    zs = pipe(ys, seq.take_while(predicate))
+    assert list(zs) == list(takewhile(predicate, xs))
+
+
+@given(st.lists(st.integers()))  # type: ignore
+def test_seq_take_while_fluent(xs: list[int]):
+    def predicate(x: int) -> bool:
+        return x >= 0
+
+    ys = seq.of_iterable(xs).take_while(predicate)
+    assert list(ys) == list(takewhile(predicate, xs))
+
+
+def test_seq_take_while_stops_on_first_false():
+    def is_even(x: int) -> bool:
+        return x % 2 == 0
+
+    xs = seq.of_iterable([2, 4, 1, 6, 8])
+    ys = pipe(xs, seq.take_while(is_even))
+    assert list(ys) == [2, 4]
+
+
+def test_seq_take_while_is_lazy():
+    def predicate(x: int) -> bool:
+        return x < 5
+
+    xs = seq.infinite
+    ys = pipe(xs, seq.take_while(predicate))
     assert list(ys) == [0, 1, 2, 3, 4]
 
 


### PR DESCRIPTION
Picks up one more function from #82. `take_while` yields elements while the predicate holds and then skips the rest, matching F# `Seq.takeWhile`.

It follows the existing `take`/`skip` style, a `@curry_flip(1)` module function plus a fluent `Seq.take_while` method, both lazy so they work on infinite sequences.

Tests cover the functional and fluent APIs (property based against `itertools.takewhile`), stopping on the first false element, and laziness on `seq.infinite`.

Verified with `uv run pytest`, `ruff check`, `ruff format --check`, and `pyright`.